### PR TITLE
Version 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix `TestCase` issue in version `1.3.2`.
 - Add `Tests_Utils` with test cases for convert meters from internal.
 - Update to [ricaun.RevitTest.TestAdapter 1.3.4](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
+- Video [RevitTest Version 1.3.4 - Revit API](https://youtu.be/B4xETYY8ft8)
 
 ## [1.0.2] / 2024-05-14
 - Update to [ricaun.RevitTest.TestAdapter 1.3.2](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] / 2024-05-27
+- Fix `TestCase` issue in version `1.3.2`.
+- Add `Tests_Utils` with test cases for convert meters from internal.
+- Update to [ricaun.RevitTest.TestAdapter 1.3.4](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
+
 ## [1.0.2] / 2024-05-14
 - Update to [ricaun.RevitTest.TestAdapter 1.3.2](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
 - Video [RevitTest Version 1.3.2 - Revit API](https://youtu.be/SFMzeS2XtuI)
@@ -17,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release - [ricaun.RevitTest.TestAdapter 1.3.0](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.0.3]: ../../compare/1.0.2...1.0.3
 [1.0.2]: ../../compare/1.0.1...1.0.2
 [1.0.1]: ../../compare/1.0.0...1.0.1
 [1.0.0]: ../../compare/1.0.0

--- a/RevitTest.Samples/RevitTest.Samples.csproj
+++ b/RevitTest.Samples/RevitTest.Samples.csproj
@@ -29,7 +29,7 @@
   </Choose>
 
   <PropertyGroup>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
   </PropertyGroup>
   
   <!-- Release -->

--- a/RevitTest.Samples/Tests_Utils.cs
+++ b/RevitTest.Samples/Tests_Utils.cs
@@ -1,0 +1,26 @@
+﻿using Autodesk.Revit.DB;
+using NUnit.Framework;
+using System;
+
+namespace RevitTest.Sample
+{
+    public class Tests_Utils
+    {
+        private const double Tolerance = 1.0e-6;
+
+        [TestCase(1.0, 0.3048)]
+        [TestCase(2.0, 0.6096)]
+        [TestCase(3.0, 0.9144)]
+        [TestCase(4.2, 1.28016)]
+        [TestCase(5.3, 1.61544)]
+        [TestCase(6.4, 1.95072)]
+        public void RevitTests_FromInternalUnits_Meters(double meters, double internalMeters)
+        {
+            var convert = UnitUtils.ConvertFromInternalUnits(meters, UnitTypeId.Meters);
+            Console.WriteLine($"{meters} to {convert}");
+            
+            var almostEqual = Math.Abs(internalMeters - convert) < Tolerance;
+            Assert.IsTrue(almostEqual);
+        }
+    }
+}


### PR DESCRIPTION
- Fix `TestCase` issue in version `1.3.2`.
- Add `Tests_Utils` with test cases for convert meters from internal.
- Update to [ricaun.RevitTest.TestAdapter 1.3.4](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
- Video [RevitTest Version 1.3.4 - Revit API](https://youtu.be/B4xETYY8ft8)