### PR TITLE
Version 1.0.5 - Support `TestCaseSource`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.0.5] / 2024-09-20
 - Update to [ricaun.RevitTest.TestAdapter 1.5.0](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
-- Video [RevitTest Version 1.5.* - TestCaseSource](https://youtu.be/qDIxW0DUKSI)
+- Video [RevitTest Version 1.5.* - TestCaseSource](https://youtu.be/8ZP5bhP_18M)
 - Version `1.5.0` features:
 	- Support `TestCaseSource` (Fix: #13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] / 2024-09-20
+- Update to [ricaun.RevitTest.TestAdapter 1.5.0](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
+- Video [RevitTest Version 1.5.* - TestCaseSource](https://youtu.be/qDIxW0DUKSI)
+- Version `1.5.0` features:
+	- Support `TestCaseSource` (Fix: #13)
+
 ## [1.0.4] / 2024-09-06
 - Update to [ricaun.RevitTest.TestAdapter 1.4.1](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
 - Video [RevitTest Version 1.4.* - Timeout and Viewer Mode](https://youtu.be/qDIxW0DUKSI)
@@ -32,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release - [ricaun.RevitTest.TestAdapter 1.3.0](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.0.5]: ../../compare/1.0.4...1.0.5
 [1.0.4]: ../../compare/1.0.3...1.0.4
 [1.0.3]: ../../compare/1.0.2...1.0.3
 [1.0.2]: ../../compare/1.0.1...1.0.2

--- a/RevitTest.Samples/RevitTest.Samples.csproj
+++ b/RevitTest.Samples/RevitTest.Samples.csproj
@@ -29,7 +29,7 @@
   </Choose>
 
   <PropertyGroup>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
   </PropertyGroup>
   
   <!-- Release -->

--- a/RevitTest.Samples/Tests_Files.cs
+++ b/RevitTest.Samples/Tests_Files.cs
@@ -1,0 +1,37 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace RevitTest.Sample
+{
+    public class Tests_Files
+    {
+        public static IEnumerable<string> GetFileNames()
+        {
+            var folder = Directory.GetCurrentDirectory();
+            return Directory.GetFiles(folder, "*RevitTest*.dll").Select(Path.GetFileName);
+        }
+
+        [TestCaseSource(nameof(GetFileNames))]
+        public void TestFile(string fileName)
+        {
+            Console.WriteLine(fileName);
+            Assert.True(true);
+        }
+
+        public static string[] GetRevitFileNames()
+        {
+            var downloadFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads");
+            return Directory.GetFiles(downloadFolder, "*.rvt");
+        }
+
+        [TestCaseSource(nameof(GetRevitFileNames))]
+        public void TestRevitFile(string fileName)
+        {
+            Console.WriteLine(fileName);
+            Assert.True(true);
+        }
+    }
+}


### PR DESCRIPTION
- Update to [ricaun.RevitTest.TestAdapter 1.5.0](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
- Video [RevitTest Version 1.5.* - TestCaseSource](https://youtu.be/8ZP5bhP_18M)
- Version `1.5.0` features:
	- Support `TestCaseSource` (Fix: #13)