### PR TITLE
Version 1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] / 2024-10-12
+- Update to [ricaun.RevitTest.TestAdapter 1.6.0](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
+- Video [RevitTest Version 1.6.* - Fake.RevitAPIUI reference](https://youtu.be/kgpfJQzA4r8)
+- Version `1.6.0` features:
+	- RevitAPIUI.Fake assembly to use in discovery (Fix: #17)
+
 ## [1.0.5] / 2024-09-20
 - Update to [ricaun.RevitTest.TestAdapter 1.5.0](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
 - Video [RevitTest Version 1.5.* - TestCaseSource](https://youtu.be/8ZP5bhP_18M)
@@ -38,6 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release - [ricaun.RevitTest.TestAdapter 1.3.0](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.0.6]: ../../compare/1.0.5...1.0.6
 [1.0.5]: ../../compare/1.0.4...1.0.5
 [1.0.4]: ../../compare/1.0.3...1.0.4
 [1.0.3]: ../../compare/1.0.2...1.0.3

--- a/RevitTest.Samples/RevitTest.Samples.csproj
+++ b/RevitTest.Samples/RevitTest.Samples.csproj
@@ -29,7 +29,7 @@
   </Choose>
 
   <PropertyGroup>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
   </PropertyGroup>
   
   <!-- Release -->


### PR DESCRIPTION
- Update to [ricaun.RevitTest.TestAdapter 1.6.0](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
- Video [RevitTest Version 1.6.* - Fake.RevitAPIUI reference](https://youtu.be/kgpfJQzA4r8)
- Version `1.6.0` features:
	- RevitAPIUI.Fake assembly to use in discovery (Fix: #17)