### PR TITLE
Version 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] / 2025-04-04
+- Update to [ricaun.RevitTest.TestAdapter 1.10.0](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
+- Video [RevitTest Version 1.10.0 - dotnet test --filter](https://youtu.be/rXmxdQFAKnk)
+### Features
+- Support `dotnet test --filter` with properties `FullyQualifiedName` and `Name`. (Fix: #30)
+- Example: [dotnet-test | Filter option details](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?tabs=dotnet-test-with-vstest#filter-option-details)
+	```bash
+	dotnet test .\RevitTest.Samples\RevitTest.Samples.csproj --filter "FullyQualifiedName~VersionBuild"
+	```
+### Tests
+- Add `RevitTests_VersionBuild` with `VersionBuild`.
+
 ## [1.1.0] / 2025-02-19
 - Update to [ricaun.RevitTest.TestAdapter 1.9.0](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
 - Video [RevitTest Version 1.9.0 - TestFixture](https://youtu.be/sxE7dfBK5Ok)
@@ -64,6 +76,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Release - [ricaun.RevitTest.TestAdapter 1.3.0](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.10.0]: ../../compare/1.1.0...1.10.0
 [1.1.0]: ../../compare/1.0.9...1.1.0
 [1.0.9]: ../../compare/1.0.8...1.0.9
 [1.0.8]: ../../compare/1.0.7...1.0.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.10.0] / 2025-04-04
 - Update to [ricaun.RevitTest.TestAdapter 1.10.0](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
-- Video [RevitTest Version 1.10.0 - dotnet test --filter](https://youtu.be/rXmxdQFAKnk)
+- Video [RevitTest Version 1.10.0 - dotnet test --filter](https://youtu.be/iq9T-jbO_90)
 ### Features
 - Support `dotnet test --filter` with properties `FullyQualifiedName` and `Name`. (Fix: #30)
 - Example: [dotnet-test | Filter option details](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?tabs=dotnet-test-with-vstest#filter-option-details)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # RevitTest.Samples
 
-[![Revit 2024](https://img.shields.io/badge/Revit-2024+-blue.svg)](../..)
-[![Visual Studio 2022](https://img.shields.io/badge/Visual%20Studio-2022-blue)](../..)
+[![Revit 2024](https://img.shields.io/badge/Revit-2024+-blue.svg)](https://github.com/ricaun-io/RevitTest/)
+[![Visual Studio 2022](https://img.shields.io/badge/Visual%20Studio-2022-blue)](https://github.com/ricaun-io/RevitTest/)
 [![Nuke](https://img.shields.io/badge/Nuke-Build-blue)](https://nuke.build/)
 [![License MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Build](../../actions/workflows/Build.yml/badge.svg)](../../actions)
+[![Build](https://github.com/ricaun-io/RevitTest/actions/workflows/Build.yml/badge.svg)](https://github.com/ricaun-io/RevitTest/actions)
 [![nuget](https://img.shields.io/nuget/v/ricaun.RevitTest.TestAdapter?logo=nuget&label=nuget&color=blue)](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
 
 [![RevitTest.Samples](assets/RevitTest.Samples.png)](https://github.com/ricaun-io/RevitTest)
@@ -336,4 +336,4 @@ This project is [licensed](LICENSE) under the [MIT License](https://en.wikipedia
 
 ---
 
-Do you like this project? Please [star this project on GitHub](../../stargazers)!
+Do you like this project? Please [star this project on GitHub](https://github.com/ricaun-io/RevitTest//stargazers)!

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RevitTest.Samples
 
-[![Revit 2019](https://img.shields.io/badge/Revit-2019+-blue.svg)](../..)
+[![Revit 2024](https://img.shields.io/badge/Revit-2024+-blue.svg)](../..)
 [![Visual Studio 2022](https://img.shields.io/badge/Visual%20Studio-2022-blue)](../..)
 [![Nuke](https://img.shields.io/badge/Nuke-Build-blue)](https://nuke.build/)
 [![License MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -9,7 +9,7 @@
 
 [![RevitTest.Samples](assets/RevitTest.Samples.png)](https://github.com/ricaun-io/RevitTest)
 
-[ricaun.RevitTest](https://github.com/ricaun-io/ricaun.RevitTest) is a multi-version NUnit testing framework for Revit API.  **Support Revit 2019 to 2025.**
+[ricaun.RevitTest](https://github.com/ricaun-io/ricaun.RevitTest) is a multi-version NUnit testing framework for Revit API.
 
 **This project contain samples and the basic info about the [ricaun.RevitTest](https://github.com/ricaun-io/ricaun.RevitTest) Framework.**
 

--- a/RevitTest.Samples/RevitTest.Samples.csproj
+++ b/RevitTest.Samples/RevitTest.Samples.csproj
@@ -29,7 +29,7 @@
   </Choose>
 
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.10.0</Version>
   </PropertyGroup>
   
   <!-- Release -->

--- a/RevitTest.Samples/RevitTest.Samples.csproj
+++ b/RevitTest.Samples/RevitTest.Samples.csproj
@@ -29,7 +29,7 @@
   </Choose>
 
   <PropertyGroup>
-    <Version>1.10.0</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
   
   <!-- Release -->

--- a/RevitTest.Samples/Tests_Application.cs
+++ b/RevitTest.Samples/Tests_Application.cs
@@ -12,6 +12,13 @@ namespace RevitTest.Sample
             Assert.IsNotNull(application);
             Console.WriteLine(application.VersionName);
         }
+
+        [Test]
+        public void RevitTests_VersionBuild()
+        {
+            Assert.IsNotNull(application);
+            Console.WriteLine(application.VersionBuild);
+        }
     }
 
     public abstract class ApplicationTests


### PR DESCRIPTION
- Update to [ricaun.RevitTest.TestAdapter 1.10.0](https://www.nuget.org/packages/ricaun.RevitTest.TestAdapter)
- Video [RevitTest Version 1.10.0 - dotnet test --filter](https://youtu.be/iq9T-jbO_90)

### Features
- Support `dotnet test --filter` with properties `FullyQualifiedName` and `Name`. (Fix: #30)
- Example: [dotnet-test | Filter option details](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?tabs=dotnet-test-with-vstest#filter-option-details)
	```bash
	dotnet test .\RevitTest.Samples\RevitTest.Samples.csproj --filter "FullyQualifiedName~VersionBuild"
	```
### Tests
- Add `RevitTests_VersionBuild` with `VersionBuild`.